### PR TITLE
Fix README clone command formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,38 @@
-# Laravel Starter Template 
+# Bússola Digital
 
-Ambiente pronto para desenvolvimento Laravel com Docker, MySQL e Traefik.
+Bússola Digital é uma aplicação web construída com Laravel. O projeto oferece um ambiente de desenvolvimento
+containerizado com Docker e MySQL para facilitar a configuração local.
 
-## Como usar
+## Requisitos
+- Docker e Docker Compose instalados
+- Opcionalmente, PHP 8.2 caso deseje executar comandos fora dos containers
 
-1. Clone este repositório:
-   ```bash
-   git clone https://github.com/mamura/docker-starter-template.git nome-do-projeto
-   cd nome-do-projeto
-   ```
+## Primeiros passos
+1. Clone o repositório:
+    ```bash
+    git clone https://github.com/mamura/bussola-digital.git
+    cd bussola-digital
+    ```
+2. Copie `.env.example` para `.env` e ajuste as variáveis.
+3. Inicie os serviços:
+    ```bash
+    docker compose up -d
+    ```
+4. Instale as dependências e gere a chave da aplicação:
+    ```bash
+    docker compose exec app composer install
+    docker compose exec app php artisan key:generate
+    ```
+
+A aplicação estará disponível em `http://localhost` ou na porta definida no `.env`.
+
+## Comandos úteis
+- `docker compose exec app php artisan migrate` executa as migrações.
+- `docker compose exec app php artisan test` roda os testes.
+
+## Estrutura do projeto
+- `docker-compose.yml` define os serviços `app` e `mysql`.
+- O código da aplicação fica dentro da pasta `src/`.
+
+## Licença
+Distribuído sob a licença MIT.


### PR DESCRIPTION
## Summary
- ensure the `git clone` command is inside the fenced code block using consistent indentation
- replace template README with project overview in Portuguese

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685bf8b3aafc8320adb4e58714f80487